### PR TITLE
docs(key-bindings): update widget descriptions

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -345,7 +345,8 @@ keymap_cursor = { emacs = "blink-block", vim_insert = "blink-block", vim_normal 
 If the cursor style is specified, the terminal's cursor style is changed to the
 specified one when the Atuin search starts with or switches to the
 corresponding keymap mode.  Also, the terminal's cursor style is reset to the
-one associated with the keymap mode corresponding to the shell's keymap.
+one associated with the keymap mode corresponding to the shell's keymap on the
+termination of the Atuin search.
 
 ## Stats
 This section of client config is specifically for configuring Atuin stats calculations

--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -63,17 +63,19 @@ ctrl_n_shortcuts = true
 
 If you'd like to customize your bindings further, it's possible to do so with custom shell config:
 
-Atuin defines the ZLE widget "\_atuin_search_widget"
+Atuin defines the ZLE widget "atuin-search"
+
+Note: use the widget name "\_atuin\_search\_widget" in `atuin <= 17.2.1` instead
 
 ```
 export ATUIN_NOBIND="true"
 eval "$(atuin init zsh)"
 
-bindkey '^r' _atuin_search_widget
+bindkey '^r' atuin-search
 
 # depends on terminal mode
-bindkey '^[[A' _atuin_search_widget
-bindkey '^[OA' _atuin_search_widget
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
 ```
 
 ## bash

--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -63,9 +63,10 @@ ctrl_n_shortcuts = true
 
 If you'd like to customize your bindings further, it's possible to do so with custom shell config:
 
-Atuin defines the ZLE widget "atuin-search"
+Atuin defines the ZLE widgets "atuin-search" and "atuin-up-search".  The latter
+can be used for the keybindings to the <kbd>up</kbd> key and similar keys.
 
-Note: use the widget name "\_atuin\_search\_widget" in `atuin <= 17.2.1` instead
+Note: instead use the widget names "\_atuin\_search\_widget" and "\_atuin\_up\_search\_widget", respectively, in `atuin <= 17.2.1`
 
 ```
 export ATUIN_NOBIND="true"
@@ -73,12 +74,16 @@ eval "$(atuin init zsh)"
 
 bindkey '^r' atuin-search
 
-# depends on terminal mode
-bindkey '^[[A' atuin-search
-bindkey '^[OA' atuin-search
+# bind to the up key, which depends on terminal mode
+bindkey '^[[A' atuin-up-search
+bindkey '^[OA' atuin-up-search
 ```
 
 ## bash
+
+Atuin provides a bindable shell function "`_atuin_history`" for keybindings in
+Bash.  The flag `--shell-up-key-binding` can be optionally specified to the
+first argument for keybindings to the <kbd>up</kbd> key or similar keys.
 
 ```
 export ATUIN_NOBIND="true"
@@ -86,6 +91,10 @@ eval "$(atuin init bash)"
 
 # bind to ctrl-r, add any other bindings you want here too
 bind -x '"\C-r": __atuin_history'
+
+# bind to the up key, which depends on terminal mode
+bind -x '"\e[A": __atuin_history --shell-up-key-binding'
+bind -x '"\eOA": __atuin_history --shell-up-key-binding'
 ```
 
 ## fish
@@ -99,6 +108,8 @@ atuin init fish | source
 bind \cr _atuin_search
 bind -M insert \cr _atuin_search
 ```
+
+For the <kbd>up</kbd> keybinding, `_atuin_bind_up` can be used instead of `_atuin_search`.
 
 Adding the useful alternative key binding of <kbd>CTRL-up</kbd> is tricky and determined by the terminals adherence to terminfo(5).
 

--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -79,6 +79,12 @@ bindkey '^[[A' atuin-up-search
 bindkey '^[OA' atuin-up-search
 ```
 
+For the keybindings in vi mode, "atuin-search-viins", "atuin-search-vicmd",
+"atuin-up-search-viins", and "atuin-up-search-vicmd" (`atuin >= 17.3`) can be
+used in combination with the config
+["keymap\_mode"](https://docs.atuin.sh/configuration/config/#keymap_mode)
+(`atuin >= 17.3`) to start the Atuin search in respective keymap modes.
+
 ## bash
 
 Atuin provides a bindable shell function "`_atuin_history`" for keybindings in
@@ -96,6 +102,13 @@ bind -x '"\C-r": __atuin_history'
 bind -x '"\e[A": __atuin_history --shell-up-key-binding'
 bind -x '"\eOA": __atuin_history --shell-up-key-binding'
 ```
+
+For the keybindings in the `vi` editing mode, the options
+`--keymap-mode=vim-insert` and `--keymap-mode=vim-normal` (`atuin >= 17.3`) can
+be additionally specified to the shell function `__atuin_history` in
+combination with the config
+["keymap\_mode"](https://docs.atuin.sh/configuration/config/#keymap_mode)
+(`atuin >= 17.3`) to start the Atuin search in respective keymap modes.
 
 ## fish
 Edit key bindings in FISH shell by adding the following to ~/.config/fish/config.fish


### PR DESCRIPTION
Commit b8c6b9a corresponds to the widget name change introduced in https://github.com/atuinsh/atuin/pull/1631. Also, the current documentation diverges from the current implementation. I updated the widgets for the <kbd>up</kbd> key in commit 6e1f3df. Also, the descriptions for the newly added widgets for `keymap_mode` (https://github.com/atuinsh/atuin/pull/1570) are added in commit 705214a.

Since the version dependence of documentation can confuse people as in https://github.com/atuinsh/atuin/issues/1625, I decided to add a note on the version dependence and also a required version for each feature. I personally think it is useful to maintain in the documentation the minimal version requirement for each feature, but this might be the perspective of a developer who needs to consider the compatibility of products with arbitrary versions of other products. If you have a different preference, please tell me that.

There is an extra commit 33a1d6d. Sorry, this is unrelated to the widget name but a tiny clarification of a description I added in my previous PR #10. If I should submit a change in a separate PR, please tell me that. It's a small change, but I'll create a separate one if you'd prefer it.
