### PR TITLE
Add infos on how to backup self-hosted DB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "docs",
+  "name": "atuin-docs",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "atuin-docs",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.3.4",
@@ -8086,9 +8087,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,10 @@
 {
-  "name": "atuin-docs",
+  "name": "docs",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "atuin-docs",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.3.4",

--- a/src/content/docs/self-hosting/docker.mdx
+++ b/src/content/docs/self-hosting/docker.mdx
@@ -105,7 +105,7 @@ systemctl status atuin
 
 You can add another service to your `docker-compose.yml` file to have it run daily backups. It should look like this:
 
-```
+```yaml
   backup:
     container_name: atuin_db_dumper
     image: prodrigestivill/postgres-backup-local

--- a/src/content/docs/self-hosting/docker.mdx
+++ b/src/content/docs/self-hosting/docker.mdx
@@ -23,6 +23,7 @@ Using the already build docker image hosting your own Atuin can be done using th
 Create a `.env` file next to `docker-compose.yml` with contents like this:
 
 ```
+ATUIN_DB_NAME=atuin
 ATUIN_DB_USERNAME=atuin
 # Choose your own secure password
 ATUIN_DB_PASSWORD=really-insecure
@@ -54,9 +55,9 @@ services:
     volumes: # Don't remove permanent storage for index database files!
       - "./database:/var/lib/postgresql/data/"
     environment:
-      POSTGRES_USER: $ATUIN_DB_USERNAME
-      POSTGRES_PASSWORD: $ATUIN_DB_PASSWORD
-      POSTGRES_DB: atuin
+      POSTGRES_USER: ${ATUIN_DB_USERNAME}
+      POSTGRES_PASSWORD: ${ATUIN_DB_PASSWORD}
+      POSTGRES_DB: ${ATUIN_DB_NAME}
 ```
 
 Start the services using `docker compose`:
@@ -99,4 +100,31 @@ Check if its running with:
 ```sh
 systemctl status atuin
 ```
+
+## Creating backups of the Postgres database
+
+You can add another service to your `docker-compose.yml` file to have it run daily backups. It should look like this:
+
+```
+  backup:
+    container_name: atuin_db_dumper
+    image: prodrigestivill/postgres-backup-local
+    env_file:
+      - .env
+    environment:
+      POSTGRES_HOST: postgresql
+      POSTGRES_DB: ${ATUIN_DB_NAME}
+      POSTGRES_USER: ${ATUIN_DB_USERNAME}
+      POSTGRES_PASSWORD: ${ATUIN_DB_PASSWORD}
+      SCHEDULE: "@daily"
+      BACKUP_DIR: /db_dumps
+    volumes:
+      - ./db_dumps:/db_dumps
+    depends_on:
+      - postgresql
+```
+
+This will create daily backups of your database for that additional layer of comfort.
+
+PLEASE NOTE: The `./db_dumps` mount MUST be a POSIX-compliant filesystem to store the backups (mainly with support for hardlinks and softlinks). So filesystems like VFAT, EXFAT, SMB/CIFS, ... can't be used with this docker image. See https://github.com/prodrigestivill/docker-postgres-backup-local for more details on how this works. There are additional settings for the number of backups retained, etc., all explained on the linked page.
 


### PR DESCRIPTION
Also bumps the version of vite since it was flagged for a security
issue.

Probably needs the same info added for Kubernetes, but I'm not really
familiar with that. :/