### PR TITLE
Fix referene to stats documentation

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -36,7 +36,7 @@ key = "~/.atuin-session"
 
 ### `dialect`
 
-This configures how the [stats](/reference/stats.md) command parses dates. It has two
+This configures how the [stats](/reference/stats/) command parses dates. It has two
 possible values
 
 ```


### PR DESCRIPTION
This PR fixes reference to `stats` subcommand documentation to point to the correct file. 