### PR TITLE
Add link to exit_mode setting for down-arrow

### DIFF
--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -181,7 +181,7 @@ $env.config = (
 | ctrl + p / ctrl + k / ⬇                  | Select the previous item on the list                                          |
 | page down                                 | Scroll search results one page down                                           |
 | page up                                   | Scroll search results one page up                                             |
-| ⬇ (with no entry selected)               | Return original or return query depending on settings                         |
+| ⬇ (with no entry selected)               | Return original or return query depending on [settings](/configuration/config/#exit_mode)                         |
 | ⬇                                        | Select the next item on the list                                              |
 
 


### PR DESCRIPTION
Just a small link update for saving me time trying to figure out which setting was it referring to. I hope I selected the right setting (tested it though, seems to be the right one). :)