### PR TITLE
Add internal link validation using Starlight Links Validator

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'astro/config';
+import starlightLinksValidator from 'starlight-links-validator'
 import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
@@ -6,6 +7,7 @@ export default defineConfig({
   site: "https://docs.atuin.sh",
   integrations: [
     starlight({
+      plugins: [starlightLinksValidator()],
       title: 'Atuin Docs',
       favicon: 'atuin.png',
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "docs",
+  "name": "atuin-docs",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
@@ -11,6 +11,7 @@
         "@astrojs/starlight": "^0.15.2",
         "astro": "^4.0.1",
         "sharp": "^0.32.5",
+        "starlight-links-validator": "^0.5.3",
         "typescript": "^5.3.3"
       }
     },
@@ -4134,6 +4135,17 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -7552,6 +7564,27 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/starlight-links-validator": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/starlight-links-validator/-/starlight-links-validator-0.5.3.tgz",
+      "integrity": "sha512-v79rwmzjQlEMVL8sZ4dalD/jhFOUvGZ2/f4CvxCySZ9KbEN9nDmgV8zJgfpmTzhbcYQ35wzyUinF4QNxgKVA4g==",
+      "dependencies": {
+        "github-slugger": "2.0.0",
+        "hast-util-from-html": "2.0.1",
+        "hast-util-has-property": "3.0.0",
+        "is-absolute-url": "4.0.1",
+        "kleur": "4.1.5",
+        "mdast-util-to-string": "4.0.0",
+        "unist-util-visit": "5.0.0"
+      },
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.15.0",
+        "astro": ">=4.0.0"
+      }
     },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/starlight": "^0.15.2",
     "astro": "^4.0.1",
     "sharp": "^0.32.5",
+    "starlight-links-validator": "^0.5.3",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
Noticed there was a plugin for Astro Starlight for internal link validation, figured it would be useful to have in the project. Documentation can be found here: https://starlight-links-validator.vercel.app. Only runs for production builds.