### PR TITLE
Update checkout action to fix node deprecation warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Install, build, and upload your site
         uses: withastro/action@v1
         # with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Install, build, and upload your site
         uses: withastro/action@v1
         # with:


### PR DESCRIPTION
The checkout action is using an older version of checkout, triggering a deprecation warning here: https://github.com/atuinsh/docs/actions/runs/7986293151.