### PR TITLE
docs: add keys section and scroll_exits option

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -273,7 +273,7 @@ history_filter = [
 
 ### `cwd_filter`
 
-The cwd filter allows you to exclude directories from history tracking. 
+The cwd filter allows you to exclude directories from history tracking.
 
 This supports regular expressions, so you can hide pretty much whatever you want!
 
@@ -505,6 +505,7 @@ scroll_exits = [...]
 ```
 
 ### `scroll_exits`
+Atuin version: >= 18.1
 
 Default: true
 

--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -436,3 +436,17 @@ common_prefix = [
 ```
 
 Configures commands that should be totally stripped from stats calculations. For example, 'sudo' should be ignored.
+
+## keys
+This section of client config is specifically for configuring key-related settings.
+
+```toml
+[stats]
+scroll_exits = [...]
+```
+
+### `scroll_exits`
+
+Default: true
+
+Configures whether the TUI exits, when scrolled past the last or first entry.

--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -441,7 +441,7 @@ Configures commands that should be totally stripped from stats calculations. For
 This section of client config is specifically for configuring key-related settings.
 
 ```toml
-[stats]
+[keys]
 scroll_exits = [...]
 ```
 


### PR DESCRIPTION
I wasn't able to add the version info, since I didn't know when this will be available: `18.0.2`, `18.0.3`, `18.1.0`, ...

Btw, I've also noticed that the `[sync]` section and the `records` option is missing from the docs. 