### PR TITLE
docs(stats): add more linux sysadmin commands to common_subcommands

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -401,12 +401,23 @@ Default
 ```
 common_subcommands = [
   "cargo",
-  "go",
+  "composer",
+  "dnf",
+  "docker",
   "git",
-  "npm",
-  "yarn",
-  "pnpm",
+  "go",
+  "ip",
   "kubectl",
+  "nix",
+  "nmcli",
+  "npm",
+  "pecl",
+  "pnpm",
+  "podman",
+  "port",
+  "systemctl",
+  "tmux",
+  "yarn",
 ]
 ```
 
@@ -424,4 +435,3 @@ common_prefix = [
 ```
 
 Configures commands that should be totally stripped from stats calculations. For example, 'sudo' should be ignored.
-

--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -400,6 +400,7 @@ Default
 
 ```
 common_subcommands = [
+  "apt",
   "cargo",
   "composer",
   "dnf",


### PR DESCRIPTION
I've been using atuin on my Linux box for some time now and I have noticed that a few commands that are used rather often are not in the list of common_subcommands.