### PR TITLE
docs: add nushell to gen-completion shell list

### DIFF
--- a/src/content/docs/reference/gen-completions.mdx
+++ b/src/content/docs/reference/gen-completions.mdx
@@ -15,6 +15,7 @@ Possible values for the `--shell` argument are the following:
 - `bash`
 - `fish`
 - `zsh`
+- `nushell`
 - `powershell`
 - `elvish`
 


### PR DESCRIPTION
Updates docs to reflect changes from https://github.com/atuinsh/atuin/pull/1791