### PR TITLE
Fix atuin dotfiles alias command example

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -472,7 +472,7 @@ Manage aliases using the command line options
 
 ```
 # Alias 'k' to 'kubectl'
-atuin dotfiles alias create k kubectl
+atuin dotfiles alias set k kubectl
 
 # List all aliases
 atuin dotfiles alias list


### PR DESCRIPTION
The command to create a new alias is `autin dotfiles alias set`, not `atuin dotfiles alias create`