### PR TITLE
Fix `--cwd` description on history list command

### DIFF
--- a/src/content/docs/reference/list.mdx
+++ b/src/content/docs/reference/list.mdx
@@ -7,8 +7,8 @@ title: history list
 
 | Arg              | Description                                                                   |
 |------------------|-------------------------------------------------------------------------------|
-| `--cwd`/`-c`     | The directory to list history for (default: all dirs)                         |
-| `--session`/`-s` | Enable listing history for the current session only (default: false)          |
+| `--cwd`/`-c`     | List history for the current directory only (default: all dirs)               |
+| `--session`/`-s` | List history for the current session only (default: false)                    |
 | `--human`        | Use human-readable formatting for the timestamp and duration (default: false) |
 | `--cmd-only`     | Show only the text of the command (default: false)                            |
 | `--reverse`      | Reverse the order of the output (default: false)                              |


### PR DESCRIPTION
The description makes it sound like it takes an argument, but it is a [boolean](https://github.com/atuinsh/atuin/blob/82a7c8d3219749dd298b23bae22456657ee92575/atuin/src/command/client/history.rs#L48-L51) and gets mad when you try to give it one. I also updated the `--session` description so they have matching sentence structure.