### PR TITLE
Use $ATUIN_DB_NAME in URL in example

### DIFF
--- a/src/content/docs/self-hosting/docker.mdx
+++ b/src/content/docs/self-hosting/docker.mdx
@@ -47,7 +47,7 @@ services:
     environment:
       ATUIN_HOST: "0.0.0.0"
       ATUIN_OPEN_REGISTRATION: "true"
-      ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/atuin
+      ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/$ATUIN_DB_NAME
       RUST_LOG: info,atuin_server=debug
   postgresql:
     image: postgres:14


### PR DESCRIPTION
In the example Dockerfile, the value of `ATUIN_DB_NAME` currently isn't passed through to the atuin service.