### PR TITLE
Add guide to enter_accept config

### DIFF
--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -18,6 +18,8 @@ filter_mode_shell_up_key_binding = "directory" # or global, host, directory, etc
 
 Our default up-arrow binding can be a bit contentious. Some people love it, some people hate it. Many people who found it a bit jarring at first have since come to love it, so give it a try!
 
+If you want the `enter` key to not execute the command directly like the `tab` key, use the [enter_accept](https://docs.atuin.sh/configuration/config/#enter_accept) config.
+
 It becomes much more powerful if you consider binding a different filter mode to the up arrow. For example, on "up" Atuin can default to searching all history for the current directory only, while ctrl-r searches history globally. See the [config](/configuration/config/#filter_mode_shell_up_key_binding) for more.
 
 Otherwise, if you don't like it, it's easy to disable.

--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -51,7 +51,7 @@ You can then choose to bind Atuin if needed, do this after the call to init.
 
 ## Enter key behavior
 
-By default, the `enter` key will directly execute the selected comamnd instead of letting you edit it like the `tab` key. If you want to change this behavior, set `enter_accept = true` in your config. For more details: [enter_accept](https://docs.atuin.sh/configuration/config/#enter_accept).
+By default, the `enter` key will directly execute the selected comamnd instead of letting you edit it like the `tab` key. If you want to change this behavior, set `enter_accept = false` in your config. For more details: [enter_accept](https://docs.atuin.sh/configuration/config/#enter_accept).
 
 ## <kbd>Ctrl-n</kbd> key shortcuts
 

--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -18,8 +18,6 @@ filter_mode_shell_up_key_binding = "directory" # or global, host, directory, etc
 
 Our default up-arrow binding can be a bit contentious. Some people love it, some people hate it. Many people who found it a bit jarring at first have since come to love it, so give it a try!
 
-If you want the `enter` key to not execute the command directly like the `tab` key, use the [enter_accept](https://docs.atuin.sh/configuration/config/#enter_accept) config.
-
 It becomes much more powerful if you consider binding a different filter mode to the up arrow. For example, on "up" Atuin can default to searching all history for the current directory only, while ctrl-r searches history globally. See the [config](/configuration/config/#filter_mode_shell_up_key_binding) for more.
 
 Otherwise, if you don't like it, it's easy to disable.
@@ -50,6 +48,10 @@ eval "$(atuin init zsh)"
 ```
 
 You can then choose to bind Atuin if needed, do this after the call to init.
+
+## Enter key behavior
+
+By default, the `enter` key will directly execute the selected comamnd instead of letting you edit it like the `tab` key. If you want to change this behavior, set `enter_accept = true` in your config. For more details: [enter_accept](https://docs.atuin.sh/configuration/config/#enter_accept).
 
 ## <kbd>Ctrl-n</kbd> key shortcuts
 


### PR DESCRIPTION
I hated the default `enter` key behavior but changing it is so obscure in the long list of config. Let's add it to the key binding page as this is where I think most people will look it up.