### PR TITLE
chore: Add Timezone and restart policy for postgres backup docker

### DIFF
--- a/src/content/docs/self-hosting/docker.mdx
+++ b/src/content/docs/self-hosting/docker.mdx
@@ -107,6 +107,7 @@ You can add another service to your `docker-compose.yml` file to have it run dai
 
 ```yaml
   backup:
+    restart: unless-stopped
     container_name: atuin_db_dumper
     image: prodrigestivill/postgres-backup-local
     env_file:
@@ -118,6 +119,7 @@ You can add another service to your `docker-compose.yml` file to have it run dai
       POSTGRES_PASSWORD: ${ATUIN_DB_PASSWORD}
       SCHEDULE: "@daily"
       BACKUP_DIR: /db_dumps
+      TZ: Europe/London
     volumes:
       - ./db_dumps:/db_dumps
     depends_on:


### PR DESCRIPTION
This PR makes two improvements to the docker-compose.yml file used for PostgreSQL backups inside doc page self-hosted docker:

  - Restart policy backup postgres docker-compose
Adds a restart policy to the backup service to improve resiliency and ensure that the service recovers automatically in case of failures. Without this explicit configuration, the backup works only once and ends, without this explicit configuration, the backup only works once and ends

  - Add Timezone on docker-compose postgres backup
Adds the TZ environment variable with the value Europe/London (example) to ensure that the container uses the correct time zone. Showing the user the possibility of changing the TZ and daily backups taking place at 00:00 in their time zone
