### PR TITLE
docs(faq): add warning for account delete

### DIFF
--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -24,11 +24,13 @@ You can make `enter` edit a command by putting `enter_accept = false` into your 
 
 ## How do I delete my account?
 
+**Attention:** This command does not prompt for confirmation.
+
 ```
 atuin account delete
 ```
 
-This will delete your account, and all history. 
+This will delete your account, and all history.
 
 ## I've forgotten my password! How can I reset it?
 


### PR DESCRIPTION
Add a warning that the command to delete all data and history does not prompt for confirmation.