### PR TITLE
feat(ultracompact): Adds setting for ultracompact mode

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -252,6 +252,15 @@ Default: `true`
 
 Configure whether or not to show tabs for search and inspect.
 
+### `auto_hide_height`
+Atuin version: >= 18.4
+
+Default: `8`
+
+Set Atuin to hide lines when a minimum number of rows is subceeded. This has no effect except
+when `compact` style is being used (see `style` above), and currently applies to only the
+interactive search and inspector. It can be turned off entirely by setting to `0`.
+
 ### `exit_mode`
 Default: `return-original` 
 


### PR DESCRIPTION
### What does this PR do?

Adds the `auto_hide_height` setting to enable/disable/configure ultracompact mode when fewer than a minimum number of lines are available and the `compact` style has been configured.

Corresponds to: https://github.com/atuinsh/atuin/pull/2319