### PR TITLE
Fix: little fix syntax from config

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -320,7 +320,7 @@ Configures whether to store commands that failed (those with non-zero exit statu
 ### `secrets_filter`
 Atuin version: >= 17.0
 
-Defatults: `true`
+Default: `true`
 
 ```toml
 secrets_filter = true


### PR DESCRIPTION
Minor correction in the writing of "default" in the configuration doc