### PR TITLE
Update key-binding.mdx

### DIFF
--- a/src/content/docs/configuration/key-binding.mdx
+++ b/src/content/docs/configuration/key-binding.mdx
@@ -100,6 +100,8 @@ eval "$(atuin init bash)"
 
 # bind to ctrl-r, add any other bindings you want here too
 bind -x '"\C-r": __atuin_history'
+# example of CTRL-upkey
+# bind -x '"\e\[1\;5A":__atuin_history'
 
 # bind to the up key, which depends on terminal mode
 bind -x '"\e[A": __atuin_history --shell-up-key-binding'


### PR DESCRIPTION
trivial amendment to show the use of an alternative binding for BASH