### PR TITLE
docker.mdx: config/ with initial uid:gid

### DIFF
--- a/src/content/docs/self-hosting/docker.mdx
+++ b/src/content/docs/self-hosting/docker.mdx
@@ -13,7 +13,10 @@ We cannot guarantee that all updates will apply cleanly, and some may require so
 There is a supplied docker image to make deploying a server as a container easier. The "LATEST TAGGED RELEASE" can be found on the [releases page](https://github.com/atuinsh/atuin/releases).
 
 ```sh
-docker run -d -v "$HOME/.config/atuin:/config" ghcr.io/atuinsh/atuin:<LATEST TAGGED RELEASE> server start
+CONFIG="$HOME/.config/atuin"
+mkdir "$CONFIG"
+chown 1000:1000 "$CONFIG"
+docker run -d -v "$CONFIG:/config" ghcr.io/atuinsh/atuin:<LATEST TAGGED RELEASE> server start
 ```
 
 # Docker Compose
@@ -63,6 +66,8 @@ services:
 Start the services using `docker compose`:
 
 ```sh
+mkdir config
+chown 1000:1000 config
 docker compose up -d
 ```
 


### PR DESCRIPTION
Avoid first run issues like:

```
Error: could not load server settings

Caused by:
   0: failed to create file `/config/server.toml`
   1: Permission denied (os error 13)

Location:
    /app/crates/atuin-server/src/settings.rs:87:28
```