### PR TITLE
Fix container name for DB URI

### DIFF
--- a/src/content/docs/self-hosting/docker.mdx
+++ b/src/content/docs/self-hosting/docker.mdx
@@ -49,7 +49,7 @@ services:
       ATUIN_OPEN_REGISTRATION: "true"
       ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/$ATUIN_DB_NAME
       RUST_LOG: info,atuin_server=debug
-  postgresql:
+  db:
     image: postgres:14
     restart: unless-stopped
     volumes: # Don't remove permanent storage for index database files!


### PR DESCRIPTION
The example `ATUIN_DB_URI` uses `@db` as the hostname, but the container was named `postgresql` which led to connection errors:

```
Location:
    /app/crates/atuin-server/src/lib.rs:143:10
Error: failed to connect to db: PostgresSettings { db_uri: "postgres://atuin:****@db/atuindb" }

Caused by:
    Other(error communicating with database: failed to lookup address information: Name or service not known

    Caused by:
        failed to lookup address information: Name or service not known

    Location:
        crates/atuin-server-postgres/src/lib.rs:53:39)

```