### PR TITLE
Remove protoc build requirement info

### DIFF
--- a/src/content/docs/guide/installation.mdx
+++ b/src/content/docs/guide/installation.mdx
@@ -38,8 +38,6 @@ If you don't wish to use the installer, the manual installation steps are as fol
         ```shell
         cargo install atuin
         ```
-
-        Please note that this requires the protobuf compiler to be installed
     </TabItem>
     <TabItem label="Homebrew">
         ```shell


### PR DESCRIPTION
Since the last [release](https://github.com/atuinsh/atuin/releases/tag/v18.4.0) protoc is not required anymore because protox is used.