### PR TITLE
Tiny: Add note on how to get debug logs from server

### DIFF
--- a/src/content/docs/self-hosting/server-setup.mdx
+++ b/src/content/docs/self-hosting/server-setup.mdx
@@ -45,6 +45,12 @@ ATUIN_DB_URI="postgres://user:password@hostname/database"
 | `db_uri`            | A valid PostgreSQL URI, for saving history (default: false)                   |
 | `path`              | A path to prepend to all routes of the server (default: false)                |
 
+### Log Levels
+
+You can set `RUST_LOG` environment variable to configure the log level for the server.
+
+For example `RUST_LOG=debug atuin server start` is useful while debugging an issue.
+
 ### TLS
 
 The server supports TLS through the `[tls]` section:


### PR DESCRIPTION
I was debugging an issue with my self-hosted instance and it took me a little bit to work out how to set the log level so I could see detailed logs. 

Added a note here to help others in future.