### PR TITLE
document keys.exit_past_line_{start,end}

### DIFF
--- a/src/content/docs/configuration/config.mdx
+++ b/src/content/docs/configuration/config.mdx
@@ -599,6 +599,22 @@ Default: `a`
 
 Which key to use as the prefix
 
+### `exit_past_line_start`
+
+Atuin version: >= 18.5
+
+Default: `true`
+
+Exits the TUI when scrolling left while the cursor is at the start of the line.
+
+### `exit_past_line_end`
+
+Atuin version: >= 18.5
+
+Default: `true`
+
+Exits the TUI when scrolling right while the cursor is at the end of the line.
+
 ## preview
 
 This section of the client config is specifically for configuring preview-related settings.


### PR DESCRIPTION
The newly introduced behavior was driving me crazy! But I was happy to find it was already configurable.

Here's an update to the docs, per: https://github.com/atuinsh/atuin/pull/2606#pullrequestreview-2669540017