### PR TITLE
Add `~/.config/atuin` deletion to uninstall docs

### DIFF
--- a/src/content/docs/uninstall.md
+++ b/src/content/docs/uninstall.md
@@ -7,8 +7,9 @@ Sorry to see you go!
 If you used the Atuin installer, you can totally delete it by removing the following
 
 1. Delete the ~/.atuin directory
-2. Delete the ~/.local/share/atuin directory
-3. Remove the line referencing "atuin init" from your shell config
+2. Delete the ~/.config/atuin directory
+3. Delete the ~/.local/share/atuin directory
+4. Remove the line referencing "atuin init" from your shell config
 
 Otherwise, uninstalling Atuin depends on your system, and how you installed it. 
 


### PR DESCRIPTION
Since the `~/.config/atuin` directory (and configuration files within) appear to be created when Atuin is first invoked, this directory should be added to the list of directories to be deleted in the uninstall documentation.